### PR TITLE
Fix configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -43,6 +43,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('shaout')->isRequired()->cannotBeEmpty()->end()
                     ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
                     ->arrayNode('api')
+                        ->isRequired()
                         ->children()
                             ->scalarNode('user')->isRequired()->cannotBeEmpty()->end()
                             ->scalarNode('password')->isRequired()->cannotBeEmpty()->end()


### PR DESCRIPTION
debug cannot be marked as `cannotBeEmpty` because 

``` yml
  debug: false
```

is empty.

Then, array `api` node is required.
