### PR TITLE
Using a more logical requirement for composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.0,<=2.3",
+        "symfony/framework-bundle": ">=2.0,<2.4",
         "jms/payment-core-bundle": "dev-master"
     },
     "require-dev": {


### PR DESCRIPTION
Till now everyone was stuck at symfony 2.3.0 .
It's a bit stupid to only miss all the fixes.
All the tests are still passing.
