### PR TITLE
Remove scoped services

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -78,11 +78,11 @@
             <argument type="service" id="payment.ogone.client.token" />
         </service>
 
-        <service id="payment.ogone.feedback_response" class="ETS\Payment\OgoneBundle\Response\FeedbackResponse" scope="request" public="false">
-            <argument type="service" id="request" />
+        <service id="payment.ogone.feedback_response" class="ETS\Payment\OgoneBundle\Response\FeedbackResponse" public="false">
+            <argument type="service" id="request_stack" />
         </service>
 
-        <service id="payment.ogone" class="ETS\Payment\OgoneBundle\Service\Ogone" scope="request">
+        <service id="payment.ogone" class="ETS\Payment\OgoneBundle\Service\Ogone">
             <argument type="service" id="payment.plugin_controller" />
             <argument type="service" id="payment.ogone.hash.sha1out" />
             <argument type="service" id="payment.ogone.feedback_response" />

--- a/Response/FeedbackResponse.php
+++ b/Response/FeedbackResponse.php
@@ -2,9 +2,9 @@
 
 namespace ETS\Payment\OgoneBundle\Response;
 
-use Symfony\Component\HttpFoundation\Request;
-
 use ETS\Payment\OgoneBundle\Hash\Sha1Out;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /*
  * Copyright 2013 ETSGlobal <ecs@etsglobal.org>
@@ -32,14 +32,16 @@ class FeedbackResponse extends AbstractResponse
     private $values = array();
     private $hash;
 
-    /**
-     * FeedbackResponse constructor
-     *
-     * @param  Request $request
-     */
-    public function __construct(Request $request)
+    public function __construct(RequestStack $requestStack)
     {
-        foreach (array_merge($request->query->all(), $request->request->all()) as $receivedField => $value) {
+        $requestParams = [];
+
+        $request = $requestStack->getCurrentRequest();
+        if ($request instanceof Request) {
+            $requestParams = array_merge($request->query->all(), $request->request->all());
+        }
+
+        foreach ($requestParams as $receivedField => $value) {
             if (Sha1Out::isAcceptableField($receivedField)) {
                 if ((string) $value !== '') {
                     $this->addValue($receivedField, $value);

--- a/Tests/Plugin/OgoneGatewayPluginTest.php
+++ b/Tests/Plugin/OgoneGatewayPluginTest.php
@@ -17,6 +17,7 @@ use ETS\Payment\OgoneBundle\Plugin\OgoneGatewayPlugin;
 use ETS\Payment\OgoneBundle\Plugin\OgoneGatewayPluginMock;
 use ETS\Payment\OgoneBundle\Response\FeedbackResponse;
 use ETS\Payment\OgoneBundle\Test\RequestStubber;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Copyright 2013 ETSGlobal <ecs@etsglobal.org>
@@ -326,8 +327,12 @@ class OgoneGatewayPluginTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetResponseReturnsFeedbackResponse(FinancialTransaction $transaction)
     {
+        $requestStack = new RequestStack();
+        $requestStack->push($this->requestStubber->getStubbedRequest());
+        $feedbackResponse = new FeedbackResponse($requestStack);
+
         $plugin = $this->createPluginMock();
-        $plugin->setFeedbackResponse(new FeedbackResponse($this->requestStubber->getStubbedRequest()));
+        $plugin->setFeedbackResponse($feedbackResponse);
 
         $class = new \ReflectionClass($plugin);
         $getResponseMethod = $class->getMethod('getResponse');

--- a/Tests/Response/FeedbackResponseTest.php
+++ b/Tests/Response/FeedbackResponseTest.php
@@ -4,13 +4,20 @@ namespace ETS\Payment\OgoneBundle\Tests\Response;
 
 use ETS\Payment\OgoneBundle\Response\FeedbackResponse;
 use ETS\Payment\OgoneBundle\Test\RequestStubber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
 
-class FeedbackResponseTest extends \PHPUnit\Framework\TestCase
+class FeedbackResponseTest extends TestCase
 {
     /**
-     * @var \ETS\Payment\OgoneBundle\Test\RequestStubber
+     * @var RequestStubber
      */
     private $requestStubber;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
 
     public function setUp()
     {
@@ -24,6 +31,8 @@ class FeedbackResponseTest extends \PHPUnit\Framework\TestCase
             array('PAYID', null, false, 43),
             array('SHASign', null, false, 'fzgzgzghz4648zh6z5h')
         ));
+
+        $this->requestStack = new RequestStack();
     }
 
     /**
@@ -32,7 +41,8 @@ class FeedbackResponseTest extends \PHPUnit\Framework\TestCase
      */
     public function testAddValueFieldAlreadySetEvenIfDifferentCase()
     {
-        $feedbackResponse = new FeedbackResponse($this->requestStubber->getStubbedRequest());
+        $this->requestStack->push($this->requestStubber->getStubbedRequest());
+        $feedbackResponse = new FeedbackResponse($this->requestStack);
 
         $class = new \ReflectionClass($feedbackResponse);
         $addValueMethod = $class->getMethod('addValue');
@@ -47,7 +57,8 @@ class FeedbackResponseTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetValueUnsetField()
     {
-        $feedbackResponse = new FeedbackResponse($this->requestStubber->getStubbedRequest());
+        $this->requestStack->push($this->requestStubber->getStubbedRequest());
+        $feedbackResponse = new FeedbackResponse($this->requestStack);
 
         $class = new \ReflectionClass($feedbackResponse);
         $getValueMethod = $class->getMethod('getValue');
@@ -58,7 +69,8 @@ class FeedbackResponseTest extends \PHPUnit\Framework\TestCase
 
     public function testConstructor()
     {
-        $feedbackResponse = new FeedbackResponse($this->requestStubber->getStubbedRequest());
+        $this->requestStack->push($this->requestStubber->getStubbedRequest());
+        $feedbackResponse = new FeedbackResponse($this->requestStack);
 
         $this->assertSame($this->requestStubber->getMapForParameterBags(false), $feedbackResponse->getValues());
         $this->assertSame($this->requestStubber->getHashFromMap(), $feedbackResponse->getHash());


### PR DESCRIPTION
Scoped services have been deprecated for a while, this PR removes scoped services by using the `request_stack` alternative